### PR TITLE
(#11) Fix tests with FUTURE_PARSER=yes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 This is a module that will manage and install the NSClient on Windows servers from the official NSClient site.
 
-[![Build Status](https://travis-ci.org/opentable/puppet-nsclient.png?branch=master)](https://travis-ci.org/opentable/puppet-nsclient)
+[![Build Status](https://travis-ci.org/puppet-community/puppet-nsclient.png?branch=master)](https://travis-ci.org/puppet-community/puppet-nsclient)
 
 
 ##Module Description

--- a/spec/classes/nsclient_spec.rb
+++ b/spec/classes/nsclient_spec.rb
@@ -52,7 +52,7 @@ describe 'nsclient', :type => :class do
     it do
       expect {
         should contain_class('nsclient')
-      }.to raise_error(Puppet::Error, /^This module only works on Windows based systems./)
+      }.to raise_error(Puppet::Error, /This module only works on Windows based systems./)
     end
   end
 


### PR DESCRIPTION
Puppet seems to have changed the reporting of the fail function:
expected Puppet::Error with message matching /^This module only works on Windows based systems./, got #<Puppet::Error: Evaluation Error: Error while evaluating a Function Call, This module only works on Windows based systems.

I also changed the README.md to fix the travis CI button.